### PR TITLE
Add typed result for parseServiceAccountFile

### DIFF
--- a/src/GmailMailer.ts
+++ b/src/GmailMailer.ts
@@ -38,6 +38,7 @@ import {
   IInitializeClientParams,
   IInitializeClientResult,
   ISendEmailFunctionResponse,
+  IParseServiceAccountResult,
 } from './types';
 
 export class GmailMailer {
@@ -63,7 +64,7 @@ export class GmailMailer {
       }
 
       if (!gmailServiceAccount && gmailServiceAccountPath) {
-        const serviceAccountResult = await parseServiceAccountFile({
+        const serviceAccountResult: IParseServiceAccountResult = await parseServiceAccountFile({
           filePath: gmailServiceAccountPath,
         });
         if (!serviceAccountResult.status || !serviceAccountResult.serviceAccount) {

--- a/src/__tests__/parseServiceAccountFile.test.ts
+++ b/src/__tests__/parseServiceAccountFile.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseServiceAccountFile } from '../utils/parseServiceAccountFile';
+import { IParseServiceAccountResult } from '../types';
 
 describe('parseServiceAccountFile', () => {
   const tempDir = path.join(__dirname, 'tmp');
@@ -18,14 +19,14 @@ describe('parseServiceAccountFile', () => {
     const content = { private_key: 'key', client_email: 'test@example.com' };
     fs.writeFileSync(filePath, JSON.stringify(content));
 
-    const res = await parseServiceAccountFile({ filePath });
+    const res: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
     expect(res.status).toBe(true);
     expect(res.serviceAccount).toEqual(content);
   });
 
   test('returns error when file missing', async () => {
     const filePath = path.join(tempDir, 'missing.json');
-    const res = await parseServiceAccountFile({ filePath });
+    const res: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
     expect(res.status).toBe(false);
     expect(res.message).toMatch('File not found');
   });
@@ -33,7 +34,7 @@ describe('parseServiceAccountFile', () => {
   test('returns error for invalid json', async () => {
     const filePath = path.join(tempDir, 'invalid.json');
     fs.writeFileSync(filePath, '{invalid json');
-    const res = await parseServiceAccountFile({ filePath });
+    const res: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
     expect(res.status).toBe(false);
     expect(res.message).toMatch('invalid JSON');
   });
@@ -41,8 +42,18 @@ describe('parseServiceAccountFile', () => {
   test('returns error for missing fields', async () => {
     const filePath = path.join(tempDir, 'missingFields.json');
     fs.writeFileSync(filePath, JSON.stringify({ client_email: 'only@example.com' }));
-    const res = await parseServiceAccountFile({ filePath });
+    const res: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
     expect(res.status).toBe(false);
     expect(res.message).toMatch("lacks required 'private_key' or 'client_email'");
+  });
+
+  test('result matches IParseServiceAccountResult shape', async () => {
+    const filePath = path.join(tempDir, 'shape.json');
+    const content = { private_key: 'key', client_email: 'shape@example.com' };
+    fs.writeFileSync(filePath, JSON.stringify(content));
+
+    const res = await parseServiceAccountFile({ filePath });
+    const keys = Object.keys(res).sort();
+    expect(keys).toEqual(['message', 'serviceAccount', 'status']);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,13 @@ export interface IGmailServiceAccount {
   client_email: string;
 }
 
+// Interface for the result of parsing a service account file
+export interface IParseServiceAccountResult {
+  status: boolean;
+  serviceAccount: IGmailServiceAccount | undefined;
+  message: string;
+}
+
 // Interface for parameters required to initialize the Gmail client
 export interface IInitializeClientParams {
   gmailServiceAccount?: IGmailServiceAccount;

--- a/src/utils/parseServiceAccountFile.ts
+++ b/src/utils/parseServiceAccountFile.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { promises as fsPromises } from 'fs';
-import { IGmailServiceAccount } from '../types';
+import { IGmailServiceAccount, IParseServiceAccountResult } from '../types';
 
 /**
  * Checks if the provided error object has a `code` property.
@@ -16,14 +16,10 @@ function hasErrorCode(error: any): error is NodeJS.ErrnoException {
  *
  * @param {Object} params - Parameters for parsing the service account file.
  * @param {string} params.filePath - The file path of the service account JSON file.
- * @returns {Promise<{status: boolean, serviceAccount: IGmailServiceAccount | undefined, message: string}>}
+ * @returns {Promise<IParseServiceAccountResult>}
  *          The result of parsing the service account file, including status, the service account object (if successful), and a message.
  */
-export async function parseServiceAccountFile({ filePath }: { filePath: string }): Promise<{
-  status: boolean;
-  serviceAccount: IGmailServiceAccount | undefined;
-  message: string;
-}> {
+export async function parseServiceAccountFile({ filePath }: { filePath: string }): Promise<IParseServiceAccountResult> {
   try {
     const absolutePath = path.resolve(filePath);
     const fileContents = await fsPromises.readFile(absolutePath, 'utf-8');


### PR DESCRIPTION
## Summary
- define `IParseServiceAccountResult` interface
- return the new interface from `parseServiceAccountFile`
- use typed result inside `GmailMailer`
- update tests to use `IParseServiceAccountResult`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6857942a0c5c832492c95a0b0d955f73